### PR TITLE
Cleanup post merging PR #6

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/maxgerhardt/ArduinoCore-bouffalo.git"
+    "url": "https://github.com/pine64/ArduinoCore-bouffalo.git"
   }
 }


### PR DESCRIPTION
Per the mention in the PR of:
> The URL in the package.json should be changed after merge

This changes the URL to correctly point to _this_ repo